### PR TITLE
feat(pollar): add escrow adapter demo at /pollar (closes #28)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ NEXT_PUBLIC_API_KEY=""
 ROZO_API_KEY=
 ROZO_APP_ID=rozoTrustlesswork
 ROZO_API_BASE_URL=https://intentapiv4.rozo.ai/functions/v1
+
+# Pollar — required only for the /pollar demo route (issue #28)
+# Get a publishable key from https://pollar.xyz
+NEXT_PUBLIC_POLLAR_PUBLISHABLE_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ memory/
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# IDE
+.idea
+/tmp

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@creit-tech/stellar-wallets-kit": "npm:@jsr/creit-tech__stellar-wallets-kit@^2.0.0-beta.6",
         "@hookform/resolvers": "^3.10.0",
         "@noble/curves": "^2.0.1",
+        "@pollar/core": "^0.6.0",
+        "@pollar/react": "^0.6.0",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2097,6 +2099,35 @@
         "@lit-labs/ssr-dom-shim": "^1.5.0",
         "@lit/reactive-element": "^2.1.0",
         "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/@pollar/core": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@pollar/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-h2rS0qIxtikDffnSc5SuXhLU7W63fMFryZy1zyra2xC9R9LbVGy+DeBik1PUPawfxLb1/HGurdUj341u/0xfWg==",
+      "dependencies": {
+        "@stellar/freighter-api": "^2.0.0",
+        "openapi-fetch": "^0.17.0"
+      }
+    },
+    "node_modules/@pollar/core/node_modules/@stellar/freighter-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-2.0.0.tgz",
+      "integrity": "sha512-j/R7MLPL8S3QhwOEdAxSl7MgWBTXWlOXQKQyXR8mPk1JMKKR4tF8e4U+Fs9TPQH0HZoYqfVDvLOOUrTMMY058Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@pollar/react": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@pollar/react/-/react-0.6.0.tgz",
+      "integrity": "sha512-Aet1+4d1uBlGABDvN9gtqZ0BVi1W5/qP+UhEVpo338FfsjlMkn01zGVoA6nm073tgOTILSsMIy6CAwdG1aEK6w==",
+      "dependencies": {
+        "@pollar/core": "*",
+        "qr.js": "^0.0.0"
+      },
+      "peerDependencies": {
+        "@pollar/core": "*",
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/@preact/signals": {
@@ -8343,21 +8374,6 @@
         "ws": "^7.5.1"
       }
     },
-    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
       "license": "MIT",
@@ -10129,6 +10145,20 @@
     "node_modules/buffer-xor": {
       "version": "1.0.3",
       "license": "MIT"
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -12996,21 +13026,6 @@
         "es6-promise": "^4.0.3"
       }
     },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/jayson/node_modules/uuid": {
       "version": "8.3.2",
       "license": "MIT",
@@ -14229,6 +14244,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
+      "integrity": "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.1.0"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
+      "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "dev": true,
@@ -14680,6 +14710,12 @@
       "dependencies": {
         "bitcoin-ops": "^1.3.0"
       }
+    },
+    "node_modules/qr.js": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==",
+      "license": "MIT"
     },
     "node_modules/qrcode": {
       "version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "@creit-tech/stellar-wallets-kit": "npm:@jsr/creit-tech__stellar-wallets-kit@^2.0.0-beta.6",
     "@hookform/resolvers": "^3.10.0",
     "@noble/curves": "^2.0.1",
+    "@pollar/core": "^0.6.0",
+    "@pollar/react": "^0.6.0",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ const EscrowsBySignerCardsNoSSR = dynamic(
 );
 
 import Link from "next/link";
-import { Briefcase } from "lucide-react";
+import { Briefcase, Sparkles } from "lucide-react";
 
 export default function Home() {
   return (
@@ -65,6 +65,23 @@ export default function Home() {
                     Click this card to enter the workspace, manage your escrows, and
                     view your milestone progress bars.
                   </p>
+                </div>
+              </div>
+            </div>
+          </Link>
+        </div>
+
+        {/* subtle entry to the Pollar adapter demo (issue #28) */}
+        <div className="w-full max-w-lg">
+          <Link href="/pollar" className="block">
+            <div className="p-3 bg-muted/20 border border-border/40 rounded-md hover:bg-muted/40 transition-colors text-sm">
+              <div className="flex items-center gap-3">
+                <Sparkles className="h-4 w-4 text-muted-foreground" />
+                <div className="flex-1">
+                  <span className="font-medium">Try Pollar mode</span>
+                  <span className="text-muted-foreground ml-2">
+                    — sign Trustless Work XDRs via Pollar (demo)
+                  </span>
                 </div>
               </div>
             </div>

--- a/src/app/pollar/layout.tsx
+++ b/src/app/pollar/layout.tsx
@@ -1,0 +1,10 @@
+import "@pollar/react/styles.css";
+import { TrustlessWorkPollarBridge } from "@/components/providers/TrustlessWorkPollarBridge";
+
+export default function PollarLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <TrustlessWorkPollarBridge>{children}</TrustlessWorkPollarBridge>;
+}

--- a/src/app/pollar/page.tsx
+++ b/src/app/pollar/page.tsx
@@ -1,0 +1,668 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import Image from "next/image";
+import {
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  ExternalLink,
+  Hammer,
+  Info,
+  Layers3,
+  ListTree,
+  Loader2,
+  RefreshCcw,
+  ShieldAlert,
+  Sparkles,
+  Wallet,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useQueryClient } from "@tanstack/react-query";
+import { usePollar, WalletButton } from "@pollar/react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
+
+import { useUpdateFromTxHash } from "@trustless-work/escrow";
+import { usePollarEscrow } from "@/lib/pollar/usePollarEscrow";
+import type {
+  EscrowType,
+  InitializeMultiReleaseEscrowPayload,
+  InitializeSingleReleaseEscrowPayload,
+} from "@trustless-work/escrow/types";
+import { PollarMyEscrowsTab } from "@/components/pollar-demo/PollarMyEscrowsTab";
+
+const USDC_TESTNET_TRUSTLINE = {
+  address: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+  symbol: "USDC",
+};
+
+function FieldLabel({
+  htmlFor,
+  children,
+  hint,
+}: {
+  htmlFor?: string;
+  children: React.ReactNode;
+  hint: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <Label htmlFor={htmlFor}>{children}</Label>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="text-muted-foreground hover:text-foreground transition-colors cursor-help"
+            aria-label="More info"
+          >
+            <Info className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="right" className="max-w-xs text-xs leading-relaxed">
+          {hint}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
+function LifecycleStep({
+  icon,
+  title,
+  cost,
+  description,
+  highlight,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  cost: string;
+  description: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      className={`flex-1 min-w-[160px] rounded-md border p-3 ${
+        highlight
+          ? "border-primary/40 bg-primary/5"
+          : "border-border/40 bg-muted/20"
+      }`}
+    >
+      <div className="flex items-center gap-2 mb-1">
+        <span className={highlight ? "text-primary" : "text-muted-foreground"}>
+          {icon}
+        </span>
+        <span className="text-sm font-medium">{title}</span>
+      </div>
+      <p className="text-xs text-muted-foreground leading-snug mb-2">
+        {description}
+      </p>
+      <Badge variant="outline" className="text-[10px] py-0 h-4">
+        {cost}
+      </Badge>
+    </div>
+  );
+}
+
+export default function PollarDemoPage() {
+  const { walletAddress, openLoginModal, tx, getClient } = usePollar();
+  const { deployEscrow } = usePollarEscrow();
+  const { updateFromTxHash } = useUpdateFromTxHash();
+  const queryClient = useQueryClient();
+
+  const [escrowType, setEscrowType] =
+    React.useState<EscrowType>("single-release");
+  const [title, setTitle] = React.useState("Demo Pollar Escrow");
+  const [description, setDescription] = React.useState(
+    "Escrow created via Pollar adapter to demonstrate XDR signing without custom glue code.",
+  );
+  const [amount, setAmount] = React.useState<string>("10");
+  const [platformFee, setPlatformFee] = React.useState<string>("5");
+  const [milestoneDescription, setMilestoneDescription] = React.useState(
+    "Deliver the demo deliverable",
+  );
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  const handleDeploy = async () => {
+    if (!walletAddress) {
+      toast.error("Connect your Pollar wallet first");
+      return;
+    }
+    const numericAmount = Number(amount);
+    const numericPlatformFee = Number(platformFee);
+    if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
+      toast.error("Amount must be a positive number");
+      return;
+    }
+    if (!Number.isFinite(numericPlatformFee) || numericPlatformFee < 0) {
+      toast.error("Platform fee must be a non-negative number");
+      return;
+    }
+
+    const baseRoles = {
+      approver: walletAddress,
+      serviceProvider: walletAddress,
+      platformAddress: walletAddress,
+      releaseSigner: walletAddress,
+      disputeResolver: walletAddress,
+    };
+
+    setIsSubmitting(true);
+    try {
+      if (escrowType === "single-release") {
+        const payload: InitializeSingleReleaseEscrowPayload = {
+          signer: walletAddress,
+          engagementId: `ENG-${Date.now()}`,
+          title,
+          description,
+          amount: numericAmount,
+          platformFee: numericPlatformFee,
+          roles: { ...baseRoles, receiver: walletAddress },
+          trustline: USDC_TESTNET_TRUSTLINE,
+          milestones: [{ description: milestoneDescription }],
+        };
+        await deployEscrow({ payload, type: "single-release" });
+      } else {
+        const payload: InitializeMultiReleaseEscrowPayload = {
+          signer: walletAddress,
+          engagementId: `ENG-${Date.now()}`,
+          title,
+          description,
+          platformFee: numericPlatformFee,
+          roles: baseRoles,
+          trustline: USDC_TESTNET_TRUSTLINE,
+          milestones: [
+            {
+              description: milestoneDescription,
+              amount: numericAmount,
+              receiver: walletAddress,
+            },
+          ],
+        };
+        await deployEscrow({ payload, type: "multi-release" });
+      }
+
+      // Pollar submits the signed XDR directly to Horizon, bypassing
+      // Trustless Work's `useSendTransaction`. The TW indexer therefore
+      // doesn't learn about the deploy on its own — we explicitly notify it
+      // with the tx hash so the new escrow is ingested.
+      const txState = getClient().getTransactionState();
+      if (txState?.step === "success" && txState.hash) {
+        try {
+          await updateFromTxHash({ txHash: txState.hash });
+        } catch (syncError) {
+          console.warn(
+            "[Pollar] updateFromTxHash failed; the escrow may take longer to appear in the indexer",
+            syncError,
+          );
+        }
+      }
+
+      toast.success("Escrow deployed — switch to My Escrows tab to see it");
+      queryClient.invalidateQueries({ queryKey: ["escrows"] });
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ["escrows"] });
+      }, 3000);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unknown error";
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const renderTxStatus = () => {
+    switch (tx.step) {
+      case "idle":
+        return (
+          <p className="text-sm text-muted-foreground">
+            No transaction yet. Fill the form and click <em>Deploy escrow</em>.
+          </p>
+        );
+      case "building":
+        return (
+          <div className="flex items-center gap-2 text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Building transaction…
+          </div>
+        );
+      case "built":
+        return (
+          <div className="flex items-center gap-2 text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Transaction built. Awaiting signature…
+          </div>
+        );
+      case "signing":
+        return (
+          <div className="flex items-center gap-2 text-sm">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Signing and submitting via Pollar…
+          </div>
+        );
+      case "success":
+        return (
+          <div className="flex flex-col gap-2 text-sm">
+            <div className="flex items-center gap-2">
+              <Badge variant="default">Success</Badge>
+              <code className="text-xs break-all">{tx.hash}</code>
+            </div>
+            <a
+              href={`https://stellar.expert/explorer/testnet/tx/${tx.hash}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-primary hover:underline"
+            >
+              View on Stellar Expert
+              <ExternalLink className="h-3.5 w-3.5" />
+            </a>
+            <p className="text-xs text-muted-foreground mt-2">
+              Note: this only created the contract on Soroban — no USDC was
+              moved. To actually fund and release, the next steps in the
+              lifecycle are <code>fundEscrow</code> →{" "}
+              <code>approveMilestone</code> → <code>releaseFunds</code>.
+            </p>
+          </div>
+        );
+      case "error":
+        return (
+          <div className="flex flex-col gap-2 text-sm">
+            <Badge variant="destructive">Error</Badge>
+            <p className="text-muted-foreground">
+              {tx.details ?? "Transaction failed"}
+            </p>
+          </div>
+        );
+    }
+  };
+
+  return (
+    <div className="font-sans min-h-screen p-8 sm:p-20">
+      <header className="flex justify-between items-center w-full mb-12">
+        <div className="flex items-center gap-4">
+          <Link
+            href="/"
+            className="p-2 hover:bg-accent rounded-full transition-colors"
+            aria-label="Back to home"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Link>
+          <Image
+            src="/favicon.ico"
+            alt="Trustless Work"
+            width={40}
+            height={40}
+          />
+          <h2 className="text-xl font-bold uppercase border-l-2 border-primary pl-4">
+            Pollar Mode
+          </h2>
+        </div>
+        <WalletButton />
+      </header>
+
+      <main className="max-w-4xl mx-auto flex flex-col gap-6">
+        <div className="border border-primary/20 bg-primary/5 rounded-lg p-4 flex items-start gap-3">
+          <Sparkles className="h-5 w-5 text-primary mt-0.5 shrink-0" />
+          <div className="text-sm">
+            <p className="font-medium mb-1">
+              Trustless Work × Pollar — escrow adapter demo (issue #28)
+            </p>
+            <p className="text-muted-foreground">
+              This page mounts <code>{"<PollarProvider>"}</code> with an{" "}
+              <code>escrow</code> adapter that wraps Trustless Work&apos;s{" "}
+              <code>useInitializeEscrow</code> hook. Calling{" "}
+              <code>usePollarEscrow().deployEscrow</code> intercepts the
+              unsigned XDR and delegates signing &amp; submission to Pollar —
+              no custom glue code in this repo.
+            </p>
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base flex items-center gap-2">
+              <Layers3 className="h-4 w-4 text-primary" />
+              How a Trustless Work escrow flows
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            <div className="flex flex-wrap items-stretch gap-2">
+              <LifecycleStep
+                highlight
+                icon={<Layers3 className="h-4 w-4" />}
+                title="1. Deploy"
+                cost="XLM only"
+                description="Create the escrow contract on Soroban with metadata (roles, expected amount, milestones, trustline). No USDC moved."
+              />
+              <div className="hidden sm:flex items-center text-muted-foreground">
+                <ArrowRight className="h-4 w-4" />
+              </div>
+              <LifecycleStep
+                icon={<Wallet className="h-4 w-4" />}
+                title="2. Fund"
+                cost="XLM + USDC"
+                description="Funder sends USDC to the contract. Requires an established USDC trustline on the funder wallet."
+              />
+              <div className="hidden sm:flex items-center text-muted-foreground">
+                <ArrowRight className="h-4 w-4" />
+              </div>
+              <LifecycleStep
+                icon={<CheckCircle2 className="h-4 w-4" />}
+                title="3. Approve & Release"
+                cost="XLM"
+                description="Approver validates each milestone; release signer transfers USDC from the contract to the receiver."
+              />
+              <div className="hidden sm:flex items-center text-muted-foreground">
+                <ArrowRight className="h-4 w-4" />
+              </div>
+              <LifecycleStep
+                icon={<ShieldAlert className="h-4 w-4" />}
+                title="Dispute (alt)"
+                cost="XLM"
+                description="Either party can start a dispute; the dispute resolver decides how funds are split between receiver and sender."
+              />
+            </div>
+            <div className="flex items-start gap-2 rounded-md bg-muted/30 border border-border/40 p-3 text-xs text-muted-foreground">
+              <Info className="h-4 w-4 shrink-0 mt-0.5 text-primary" />
+              <p>
+                <strong>This demo implements only step 1 (Deploy).</strong>{" "}
+                That&apos;s enough to validate the Pollar adapter pattern — the
+                other 7 signing operations (<code>fundEscrow</code>,{" "}
+                <code>releaseFunds</code>, <code>approveMilestone</code>,{" "}
+                <code>changeMilestoneStatus</code>, <code>startDispute</code>,{" "}
+                <code>resolveDispute</code>, <code>updateEscrow</code>) follow
+                the same pattern and are tracked as TODO in{" "}
+                <code>src/lib/pollar/escrowAdapter.types.ts</code>. See the{" "}
+                <a
+                  href="https://docs.trustlesswork.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary hover:underline inline-flex items-center gap-1"
+                >
+                  Trustless Work docs
+                  <ExternalLink className="h-3 w-3" />
+                </a>{" "}
+                for the full lifecycle.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Tabs defaultValue="deploy" className="w-full">
+          <TabsList>
+            <TabsTrigger value="deploy" className="gap-2">
+              <Hammer className="h-4 w-4" />
+              Deploy
+            </TabsTrigger>
+            <TabsTrigger value="my-escrows" className="gap-2">
+              <ListTree className="h-4 w-4" />
+              My Escrows
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="deploy" className="flex flex-col gap-6 mt-4">
+            {!walletAddress ? (
+              <Card>
+                <CardHeader>
+                  <CardTitle>Connect with Pollar</CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-col gap-4">
+                  <p className="text-sm text-muted-foreground">
+                    Sign in via Google, GitHub, email or an existing Stellar
+                    wallet through Pollar to start.
+                  </p>
+                  <Button onClick={openLoginModal}>Open Pollar login</Button>
+                </CardContent>
+              </Card>
+            ) : (
+              <>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Deploy a demo escrow</CardTitle>
+                  </CardHeader>
+                  <CardContent className="flex flex-col gap-4">
+                    <div className="grid gap-2">
+                      <FieldLabel
+                        htmlFor="escrow-type"
+                        hint={
+                          <>
+                            <strong>Single release:</strong> one bulk release
+                            of the full amount when the (single) milestone is
+                            approved.
+                            <br />
+                            <strong>Multi release:</strong> separate release
+                            per milestone, each with its own amount and
+                            receiver. Use for multi-stage engagements.
+                          </>
+                        }
+                      >
+                        Escrow type
+                      </FieldLabel>
+                      <Select
+                        value={escrowType}
+                        onValueChange={(v) => setEscrowType(v as EscrowType)}
+                      >
+                        <SelectTrigger id="escrow-type">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="single-release">
+                            Single release
+                          </SelectItem>
+                          <SelectItem value="multi-release">
+                            Multi release
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <div className="grid gap-2">
+                      <FieldLabel
+                        htmlFor="title"
+                        hint="Display name for the escrow. Free-text, stored on-chain as metadata."
+                      >
+                        Title
+                      </FieldLabel>
+                      <Input
+                        id="title"
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                      />
+                    </div>
+
+                    <div className="grid gap-2">
+                      <FieldLabel
+                        htmlFor="description"
+                        hint="What the escrow is for. Free-text metadata visible to all parties."
+                      >
+                        Description
+                      </FieldLabel>
+                      <Textarea
+                        id="description"
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        rows={2}
+                      />
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                      <div className="grid gap-2">
+                        <FieldLabel
+                          htmlFor="amount"
+                          hint={
+                            escrowType === "single-release" ? (
+                              <>
+                                Total USDC the escrow expects to be funded
+                                with.{" "}
+                                <strong>
+                                  No USDC moves at deploy time
+                                </strong>
+                                ; the value is stored as metadata so step 2
+                                (fundEscrow) knows the target amount.
+                              </>
+                            ) : (
+                              <>
+                                USDC released when this milestone is approved.
+                                In multi-release, the total funding is the sum
+                                of all milestone amounts. No USDC moves at
+                                deploy.
+                              </>
+                            )
+                          }
+                        >
+                          {escrowType === "single-release"
+                            ? "Amount (USDC)"
+                            : "Milestone amount (USDC)"}
+                        </FieldLabel>
+                        <Input
+                          id="amount"
+                          type="number"
+                          min="0"
+                          step="0.01"
+                          value={amount}
+                          onChange={(e) => setAmount(e.target.value)}
+                        />
+                      </div>
+                      <div className="grid gap-2">
+                        <FieldLabel
+                          htmlFor="platform-fee"
+                          hint={
+                            <>
+                              Commission percentage taken by{" "}
+                              <code>platformAddress</code> when funds are
+                              released. A value of <code>5</code> means 5%.
+                            </>
+                          }
+                        >
+                          Platform fee (%)
+                        </FieldLabel>
+                        <Input
+                          id="platform-fee"
+                          type="number"
+                          min="0"
+                          step="0.01"
+                          value={platformFee}
+                          onChange={(e) => setPlatformFee(e.target.value)}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="grid gap-2">
+                      <FieldLabel
+                        htmlFor="milestone-description"
+                        hint="What the service provider must complete for this milestone. Approver checks it later before approving release."
+                      >
+                        Milestone description
+                      </FieldLabel>
+                      <Input
+                        id="milestone-description"
+                        value={milestoneDescription}
+                        onChange={(e) =>
+                          setMilestoneDescription(e.target.value)
+                        }
+                      />
+                    </div>
+
+                    <div className="rounded-md bg-muted/30 border border-border/40 p-3 text-xs text-muted-foreground flex items-start gap-2">
+                      <Info className="h-4 w-4 shrink-0 mt-0.5" />
+                      <div className="space-y-2">
+                        <p>
+                          <strong>Roles:</strong> for demo simplicity, every
+                          role is set to your connected Pollar wallet.
+                        </p>
+                        <ul className="list-disc list-inside space-y-1 pl-1">
+                          <li>
+                            <code>approver</code> — validates milestones
+                            before release
+                          </li>
+                          <li>
+                            <code>serviceProvider</code> — does the work
+                          </li>
+                          <li>
+                            <code>releaseSigner</code> — signs the release tx
+                          </li>
+                          <li>
+                            <code>disputeResolver</code> — splits funds if
+                            disputed
+                          </li>
+                          <li>
+                            <code>platformAddress</code> — receives the
+                            platform fee
+                          </li>
+                          <li>
+                            <code>receiver</code> — gets the released USDC
+                            (single release only; in multi-release each
+                            milestone has its own)
+                          </li>
+                        </ul>
+                        <p>
+                          <strong>Trustline:</strong> hardcoded to USDC on
+                          Stellar testnet. The contract uses this as the asset
+                          it expects when funded.
+                        </p>
+                      </div>
+                    </div>
+
+                    <Button
+                      onClick={handleDeploy}
+                      disabled={isSubmitting || tx.step === "signing"}
+                      className="w-full"
+                    >
+                      {isSubmitting || tx.step === "signing" ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                          Deploying…
+                        </>
+                      ) : (
+                        <>
+                          <RefreshCcw className="h-4 w-4 mr-2" />
+                          Deploy escrow
+                        </>
+                      )}
+                    </Button>
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader>
+                    <CardTitle>Transaction status</CardTitle>
+                  </CardHeader>
+                  <CardContent>{renderTxStatus()}</CardContent>
+                </Card>
+              </>
+            )}
+          </TabsContent>
+
+          <TabsContent value="my-escrows" className="mt-4">
+            <PollarMyEscrowsTab />
+          </TabsContent>
+        </Tabs>
+      </main>
+    </div>
+  );
+}

--- a/src/components/pollar-demo/PollarEscrowCard.tsx
+++ b/src/components/pollar-demo/PollarEscrowCard.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import * as React from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Receipt, Clock, CheckCircle2, XCircle } from "lucide-react";
+import type {
+  GetEscrowsFromIndexerResponse as Escrow,
+  MultiReleaseMilestone,
+} from "@trustless-work/escrow/types";
+import { formatCurrency } from "@/components/tw-blocks/helpers/format.helper";
+
+type DisplayStatus = "disputed" | "resolved" | "released" | "working";
+
+function getEscrowStatus(escrow: Escrow): DisplayStatus {
+  if (escrow.flags?.disputed) return "disputed";
+  if (escrow.flags?.resolved) return "resolved";
+  if (escrow.flags?.released) return "released";
+  return "working";
+}
+
+function StatusBadge({ status }: { status: DisplayStatus }) {
+  const map: Record<
+    DisplayStatus,
+    { label: string; variant: "default" | "secondary" | "destructive" | "outline" }
+  > = {
+    disputed: { label: "Disputed", variant: "destructive" },
+    resolved: { label: "Resolved", variant: "outline" },
+    released: { label: "Released", variant: "default" },
+    working: { label: "Working", variant: "outline" },
+  };
+  const { label, variant } = map[status];
+  return <Badge variant={variant}>{label}</Badge>;
+}
+
+function StatusIcon({ status }: { status: DisplayStatus }) {
+  switch (status) {
+    case "disputed":
+      return <XCircle className="h-4 w-4 text-destructive" />;
+    case "resolved":
+    case "released":
+      return <CheckCircle2 className="h-4 w-4 text-green-600" />;
+    case "working":
+      return <Clock className="h-4 w-4 text-muted-foreground" />;
+  }
+}
+
+function escrowAmount(escrow: Escrow): number {
+  if (escrow.type === "single-release") {
+    return escrow.amount ?? 0;
+  }
+  return (
+    escrow.milestones?.reduce(
+      (sum, m) => sum + ((m as MultiReleaseMilestone).amount ?? 0),
+      0,
+    ) ?? 0
+  );
+}
+
+function shortContractId(contractId?: string): string {
+  if (!contractId) return "-";
+  if (contractId.length <= 12) return contractId;
+  return `${contractId.slice(0, 6)}…${contractId.slice(-4)}`;
+}
+
+export function PollarEscrowCard({ escrow }: { escrow: Escrow }) {
+  const status = getEscrowStatus(escrow);
+  const amount = escrowAmount(escrow);
+  const symbol = escrow.trustline?.symbol ?? "USDC";
+
+  return (
+    <Card className="gap-3 hover:shadow-md transition-shadow">
+      <CardHeader className="space-y-2">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <Receipt className="h-4 w-4 text-muted-foreground" />
+            <Badge variant="outline" className="text-xs">
+              {escrow.type === "single-release" ? "Single" : "Multi"}
+            </Badge>
+          </div>
+          <StatusIcon status={status} />
+        </div>
+        <CardTitle className="text-base line-clamp-2">
+          {escrow.title || "Untitled escrow"}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div>
+          <p className="text-xs text-muted-foreground mb-1">Amount</p>
+          <p className="text-xl font-bold">{formatCurrency(amount, symbol)}</p>
+        </div>
+
+        {escrow.engagementId && (
+          <div>
+            <p className="text-xs text-muted-foreground mb-1">Engagement</p>
+            <p className="text-sm font-mono">{escrow.engagementId}</p>
+          </div>
+        )}
+
+        <div>
+          <p className="text-xs text-muted-foreground mb-1">Contract</p>
+          <p className="text-xs font-mono">
+            {shortContractId(escrow.contractId)}
+          </p>
+        </div>
+
+        <div className="flex items-center justify-between pt-2 border-t">
+          <div>
+            <p className="text-xs text-muted-foreground">Status</p>
+            <div className="mt-1">
+              <StatusBadge status={status} />
+            </div>
+          </div>
+          <div className="text-right">
+            <p className="text-xs text-muted-foreground">Created</p>
+            <p className="text-xs font-medium mt-1">
+              {escrow.createdAt?._seconds
+                ? new Date(
+                    escrow.createdAt._seconds * 1000,
+                  ).toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                  })
+                : "-"}
+            </p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/pollar-demo/PollarMyEscrowsTab.tsx
+++ b/src/components/pollar-demo/PollarMyEscrowsTab.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import * as React from "react";
+import { usePollar } from "@pollar/react";
+import { Loader2, RefreshCcw, Search, FileX } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { useEscrowsBySignerQuery } from "@/components/tw-blocks/tanstack/useEscrowsBySignerQuery";
+import { PollarEscrowCard } from "./PollarEscrowCard";
+
+type TypeFilter = "all" | "single-release" | "multi-release";
+type StatusFilter =
+  | "all"
+  | "working"
+  | "pendingRelease"
+  | "released"
+  | "resolved"
+  | "inDispute";
+
+function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = React.useState<T>(value);
+  React.useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+  return debounced;
+}
+
+export function PollarMyEscrowsTab() {
+  const { walletAddress } = usePollar();
+
+  const [titleFilter, setTitleFilter] = React.useState("");
+  const [type, setType] = React.useState<TypeFilter>("all");
+  const [status, setStatus] = React.useState<StatusFilter>("all");
+
+  const debouncedTitle = useDebouncedValue(titleFilter, 300);
+
+  const queryParams = {
+    signer: walletAddress ?? "",
+    page: 1,
+    orderBy: "createdAt" as const,
+    orderDirection: "desc" as const,
+    // Defensive defaults for the demo: don't filter by isActive (returns all),
+    // and validate on-chain so freshly-deployed escrows surface even if the
+    // indexer hasn't yet flipped their isActive flag.
+    validateOnChain: true,
+    title: debouncedTitle || undefined,
+    type: type === "all" ? undefined : type,
+    status: status === "all" ? undefined : status,
+    enabled: !!walletAddress,
+  };
+
+  const { data, isLoading, isError, isFetching, refetch, dataUpdatedAt } =
+    useEscrowsBySignerQuery(queryParams);
+
+  const escrows = data ?? [];
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col sm:flex-row gap-2 items-stretch sm:items-center">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search by title…"
+            value={titleFilter}
+            onChange={(e) => setTitleFilter(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <Select
+          value={type}
+          onValueChange={(v) => setType(v as TypeFilter)}
+        >
+          <SelectTrigger className="w-full sm:w-44">
+            <SelectValue placeholder="Type" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All types</SelectItem>
+            <SelectItem value="single-release">Single release</SelectItem>
+            <SelectItem value="multi-release">Multi release</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select
+          value={status}
+          onValueChange={(v) => setStatus(v as StatusFilter)}
+        >
+          <SelectTrigger className="w-full sm:w-44">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All statuses</SelectItem>
+            <SelectItem value="working">Working</SelectItem>
+            <SelectItem value="pendingRelease">Pending release</SelectItem>
+            <SelectItem value="released">Released</SelectItem>
+            <SelectItem value="resolved">Resolved</SelectItem>
+            <SelectItem value="inDispute">In dispute</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => refetch()}
+          disabled={isFetching}
+          aria-label="Refresh"
+          title="Refresh"
+        >
+          <RefreshCcw
+            className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+          />
+        </Button>
+      </div>
+
+      <details className="text-xs text-muted-foreground rounded-md border border-border/40 bg-muted/10">
+        <summary className="cursor-pointer px-3 py-2 font-mono">
+          Debug · {escrows.length} escrow{escrows.length === 1 ? "" : "s"}
+          {dataUpdatedAt
+            ? ` · last refetch ${new Date(dataUpdatedAt).toLocaleTimeString()}`
+            : ""}
+        </summary>
+        <pre className="px-3 pb-2 overflow-x-auto">
+          {JSON.stringify(
+            {
+              signer: queryParams.signer,
+              type: queryParams.type ?? null,
+              status: queryParams.status ?? null,
+              title: queryParams.title ?? null,
+              validateOnChain: queryParams.validateOnChain,
+              enabled: queryParams.enabled,
+              isFetching,
+              isError,
+            },
+            null,
+            2,
+          )}
+        </pre>
+      </details>
+
+      {!walletAddress ? (
+        <Empty className="border-border text-center">
+          <EmptyHeader>
+            <EmptyTitle>Wallet not connected</EmptyTitle>
+            <EmptyDescription>
+              Connect with Pollar (top-right) to see escrows where you are the
+              signer.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : isLoading ? (
+        <div className="flex flex-col items-center justify-center py-12 gap-3">
+          <Loader2 className="h-6 w-6 animate-spin text-primary" />
+          <p className="text-sm text-muted-foreground">Loading escrows…</p>
+        </div>
+      ) : isError ? (
+        <Empty className="border-border text-center">
+          <EmptyHeader>
+            <EmptyTitle>Error loading escrows</EmptyTitle>
+            <EmptyDescription>
+              Something went wrong. Try again.
+            </EmptyDescription>
+            <Button
+              variant="outline"
+              onClick={() => refetch()}
+              className="mt-4"
+            >
+              Retry
+            </Button>
+          </EmptyHeader>
+        </Empty>
+      ) : escrows.length === 0 ? (
+        <Empty className="border-border text-center">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <FileX className="size-6 text-muted-foreground" />
+            </EmptyMedia>
+            <EmptyTitle>No escrows yet</EmptyTitle>
+            <EmptyDescription>
+              Deploy your first escrow from the <strong>Deploy</strong> tab and
+              it will appear here. The indexer can take a few seconds to ingest
+              a new escrow — click <strong>Refresh</strong> if you just
+              deployed.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {escrows.map((escrow) => (
+            <PollarEscrowCard
+              key={escrow.contractId ?? escrow.engagementId}
+              escrow={escrow}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/providers/TrustlessWorkPollarBridge.tsx
+++ b/src/components/providers/TrustlessWorkPollarBridge.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import * as React from "react";
+import { PollarProvider } from "@pollar/react";
+import { useInitializeEscrow } from "@trustless-work/escrow";
+import type { EscrowAdapter } from "@/lib/pollar/escrowAdapter.types";
+
+interface TrustlessWorkPollarBridgeProps {
+  children: React.ReactNode;
+}
+
+// Bridge component that lives inside <TrustlessWorkConfig>, extracts the
+// Trustless Work signing functions (currently just `deployEscrow`), wraps
+// them as a Pollar adapter, and mounts <PollarProvider> with that adapter.
+//
+// Descendants can then use `usePollarEscrow()` to call the signing ops
+// without ever touching the unsigned XDR — Pollar signs and submits.
+export function TrustlessWorkPollarBridge({
+  children,
+}: TrustlessWorkPollarBridgeProps) {
+  const { deployEscrow: twDeployEscrow } = useInitializeEscrow();
+
+  const escrow = React.useMemo<EscrowAdapter>(
+    () => ({
+      deployEscrow: async ({ payload, type }) => {
+        const response = await twDeployEscrow(payload, type);
+        if (!response.unsignedTransaction) {
+          throw new Error(
+            "Trustless Work deployEscrow returned no unsignedTransaction",
+          );
+        }
+        return { unsignedTransaction: response.unsignedTransaction };
+      },
+    }),
+    [twDeployEscrow],
+  );
+
+  const apiKey = process.env.NEXT_PUBLIC_POLLAR_PUBLISHABLE_KEY;
+
+  if (!apiKey) {
+    return (
+      <div className="p-8 max-w-xl mx-auto mt-16 border border-destructive/40 bg-destructive/10 rounded-lg">
+        <h2 className="text-lg font-semibold mb-2">
+          Pollar is not configured
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Set <code>NEXT_PUBLIC_POLLAR_PUBLISHABLE_KEY</code> in your{" "}
+          <code>.env</code> to enable the <code>/pollar</code> demo.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <PollarProvider config={{ apiKey, baseUrl: 'http://localhost:3052' }} adapters={{ escrow }}>
+      {children}
+    </PollarProvider>
+  );
+}

--- a/src/lib/pollar/escrowAdapter.types.ts
+++ b/src/lib/pollar/escrowAdapter.types.ts
@@ -1,0 +1,21 @@
+import type { EscrowAdapter as PollarEscrowAdapter, EscrowFn } from "@pollar/core";
+import type {
+  EscrowType,
+  InitializeMultiReleaseEscrowPayload,
+  InitializeSingleReleaseEscrowPayload,
+} from "@trustless-work/escrow/types";
+
+export type DeployEscrowAdapterParams = {
+  payload:
+    | InitializeSingleReleaseEscrowPayload
+    | InitializeMultiReleaseEscrowPayload;
+  type: EscrowType;
+};
+
+// V1: only `deployEscrow` is wired. The other 7 Trustless Work signing ops
+// (fundEscrow, releaseFunds, approveMilestone, changeMilestoneStatus,
+// startDispute, resolveDispute, updateEscrow) follow the same pattern and
+// will be added in a follow-up.
+export interface EscrowAdapter extends PollarEscrowAdapter {
+  deployEscrow: EscrowFn<DeployEscrowAdapterParams>;
+}

--- a/src/lib/pollar/usePollarEscrow.ts
+++ b/src/lib/pollar/usePollarEscrow.ts
@@ -1,0 +1,10 @@
+"use client";
+
+import { createPollarAdapterHook } from "@pollar/react";
+import type { EscrowAdapter } from "./escrowAdapter.types";
+
+// `createPollarAdapterHook` reads `adapters[key]` from the PollarProvider
+// context, then wraps each adapter function so that calling it transparently
+// runs: original fn → unsignedTransaction → signAndSubmitTx via Pollar.
+export const usePollarEscrow =
+  createPollarAdapterHook<EscrowAdapter>("escrow");


### PR DESCRIPTION
## Summary

Adds a Pollar-based escrow flow at `/pollar`, demonstrating that Trustless Work
XDR signing can be delegated to Pollar's wallet without custom glue code by
consuming Pollar's existing generic adapter primitive (`createPollarAdapterHook`).

The route is self-contained — existing flows (`/`, `/dashboard`, `/admin`,
etc.) are untouched and continue using Stellar Wallets Kit.

## Why no changes to @pollar/core or @pollar/react

The Pollar SDK already ships a generic adapter mechanism that fits this issue:

- `PollarProvider` accepts `adapters?: PollarAdapters` (string-keyed map).
- `createPollarAdapterHook<T>(key)` implements the
  "intercept `unsignedTransaction` → `signAndSubmitTx`" pattern.
- `signAndSubmitTx` is exposed on the Pollar context.

No new abstraction was needed. The `EscrowAdapter` type and `usePollarEscrow`
hook are defined in this repo as a thin Trustless Work–specific layer on top
of Pollar's generic primitives. If they prove stable they can be promoted
into `@pollar/react` later as a backward-compatible addition.

## What's demonstrated

- `/pollar` mounts `<PollarProvider adapters={{ escrow }}>` only when the
  user enters that route (nested layout — root layout untouched).
- **Deploy form**: Pollar `WalletButton` for OAuth (Google, GitHub, email, or
  external Stellar wallets), single-release / multi-release toggle, tooltips
  on every field, and a lifecycle card explaining the four phases of a
  Trustless Work escrow (deploy → fund → release/dispute) and why deploy
  itself doesn't move USDC.
- **My Escrows tab**: lists escrows where the connected Pollar wallet is the
  signer, with title search, type filter, status filter, and refresh.
- Subtle "Try Pollar mode" entry on the home page linking to the demo.

## Implementation

The integration is three small pieces.

**1. Typed adapter shape** — `src/lib/pollar/escrowAdapter.types.ts`

```ts
import type { EscrowAdapter as PollarEscrowAdapter, EscrowFn } from "@pollar/core";
import type {
  EscrowType,
  InitializeMultiReleaseEscrowPayload,
  InitializeSingleReleaseEscrowPayload,
} from "@trustless-work/escrow/types";

export interface EscrowAdapter extends PollarEscrowAdapter {
  deployEscrow: EscrowFn<{
    payload:
      | InitializeSingleReleaseEscrowPayload
      | InitializeMultiReleaseEscrowPayload;
    type: EscrowType;
  }>;
}
```

**2. Bridge** — `src/components/providers/TrustlessWorkPollarBridge.tsx`

Lives inside `<TrustlessWorkProvider>`, calls the TW SDK hook, wraps it as a
Pollar adapter, and mounts `<PollarProvider>`:

```tsx
const { deployEscrow: twDeployEscrow } = useInitializeEscrow();

const escrow = React.useMemo<EscrowAdapter>(
  () => ({
    deployEscrow: async ({ payload, type }) => {
      const response = await twDeployEscrow(payload, type);
      if (!response.unsignedTransaction) {
        throw new Error("deployEscrow returned no unsignedTransaction");
      }
      return { unsignedTransaction: response.unsignedTransaction };
    },
  }),
  [twDeployEscrow],
);

return (
  <PollarProvider config={{ apiKey }} adapters={{ escrow }}>
    {children}
  </PollarProvider>
);
```

**3. Consumer hook** — `src/lib/pollar/usePollarEscrow.ts`

```ts
import { createPollarAdapterHook } from "@pollar/react";
import type { EscrowAdapter } from "./escrowAdapter.types";

export const usePollarEscrow =
  createPollarAdapterHook<EscrowAdapter>("escrow");
```

Usage from any descendant:

```tsx
const { deployEscrow } = usePollarEscrow();
await deployEscrow({ payload, type: "single-release" });
// Pollar intercepts the unsigned XDR, signs it, and submits — no XDR plumbing
// needed in product code.
```

## Files

**New**
- `src/app/pollar/{layout,page}.tsx` — demo route + nested layout.
- `src/components/providers/TrustlessWorkPollarBridge.tsx` — wires TW hooks
  through to a Pollar adapter and mounts `<PollarProvider>`.
- `src/components/pollar-demo/{PollarMyEscrowsTab,PollarEscrowCard}.tsx` —
  escrow listing scoped to the Pollar wallet.
- `src/lib/pollar/{escrowAdapter.types,usePollarEscrow}.ts` — local
  `EscrowAdapter` type and ready-made hook.

**Modified**
- `src/app/page.tsx` — subtle "Try Pollar mode" card.
- `.env.example` — `NEXT_PUBLIC_POLLAR_PUBLISHABLE_KEY`.
- `package.json` / `package-lock.json` — adds `@pollar/react`.

**Untouched**
- Root `src/app/layout.tsx` (no provider tree changes outside `/pollar`).
- All other routes.
- `tw-blocks/*` (no shared component refactored).

## How to test

1. Set `NEXT_PUBLIC_POLLAR_PUBLISHABLE_KEY` in `.env`.
2. `npm install && npm run dev`.
3. Open `http://localhost:3000` → click **Try Pollar mode** → land on `/pollar`.
4. Sign in via Pollar (Google OAuth or any other configured method).
5. On the **Deploy** tab, click **Deploy escrow** with the default values.
6. Confirm signing in the Pollar modal.
7. Toast shows `Success` plus the tx hash. Click the Stellar Expert link to
   verify the contract is on-chain.
8. Switch to **My Escrows** to see the deployed escrow card.

## Next steps

This PR lands the foundation. The roadmap from here:

### 1. Cover the remaining seven signing operations

V1 implements only `deployEscrow`. The other operations follow the same
pattern and are tracked as TODO in `src/lib/pollar/escrowAdapter.types.ts`:

| Operation | Trustless Work hook |
|---|---|
| `fundEscrow` | `useFundEscrow` |
| `releaseFunds` | `useReleaseFunds` |
| `approveMilestone` | `useApproveMilestone` |
| `changeMilestoneStatus` | `useChangeMilestoneStatus` |
| `startDispute` | `useStartDispute` |
| `resolveDispute` | `useResolveDispute` |
| `updateEscrow` | `useUpdateEscrow` |

Each one is a one-line addition to `EscrowAdapter` plus the corresponding TW
hook in the bridge. Once this PR merges, growing the surface is mechanical
and can be parallelized across PRs.

### 2. Add a sign-only primitive to `@pollar/core`

Today Pollar's `signAndSubmitTx` signs **and** submits the XDR directly to
Horizon. A small additive change — exposing `signTransaction(xdr) → signedXdr`
on `PollarClient` and the React context — would let consumers use Trustless
Work's `useSendTransaction` for submission, restoring the round-trip
`TW → sign → TW → indexer` and unblocking automatic indexer sync for
Pollar-driven deploys.

Estimated footprint: ~15 lines across `@pollar/core` and `@pollar/react`.
Backward-compatible (additive, no breaking change).

### 3. UX polish

- Surface the contract ID inline after a successful deploy (currently
  reachable via the Stellar Expert link only).
- Copy-to-clipboard buttons for the tx hash and contract ID.
- Auto-poll **My Escrows** for ~30 seconds after a deploy to bridge indexer
  lag, or surface a per-escrow status badge that flips to "Indexed" when it
  appears.

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Pollar wallet support enabling escrow deployment and management
  * Added new Pollar demo page accessible from the home page
  * Escrow configuration UI for creating single and multi-release escrows with customizable parameters
  * View and filter deployed escrows by status and type
  * Transaction status tracking with explorer links on successful deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->